### PR TITLE
Copy editing README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Gogs is a self-hosted Git service written in Go. Alternative to Github.
 - [Gogs website](http://gogs.io)
 
 ## Requirements
-- Functionnal instance of [YunoHost](https://yunohost.org)
+A functional instance of [YunoHost](https://yunohost.org)
 
 ## Installation
-From command line:
+From the command-line:
 
 `sudo yunohost app install -l Gogs https://github.com/YunoHost-Apps/gogs_ynh`
 
 ## Upgrade
-From command line:
+From the command-line:
 
 `sudo yunohost app upgrade -u https://github.com/YunoHost-Apps/gogs_ynh gogs`
 
 ## Notes on SSH usage
-If you want to use gogs with ssh and be able to pull/push with you ssh key, your ssh daemon need to be properly configured to use private/public key. Here is a sample configuration (in `/etc/ssh/sshd_config` that works with gogs:
+If you want to use Gogs with ssh and be able to pull/push with you ssh key, your ssh daemon must be properly configured to use private/public keys. Here is a sample configuration of `/etc/ssh/sshd_config` that works with Gogs:
 
 ```bash
 PubkeyAuthentication yes
@@ -27,37 +27,38 @@ PasswordAuthentication no
 UsePAM no
 ```
 
-You also need to add your public key to your gogs profile.
+You also need to add your public key to your Gogs profile.
 
-If you use ssh on another port than 22, you need to add theses lines to your ssh config in `~/.ssh/config`
+If you use ssh on another port than 22, you need to add theses lines to your ssh config in `~/.ssh/config`:
+
 ```bash
 Host domain.tld
     port 2222 # change this with the port you use
 ```
 
-## Infos on upgrade from the old package version (gogs <0.9.xx)
-Previous versions of this package used to build gogs from sources instead of using precompiled binary. It also leave data to many places which was not good. The upgrade try to take care of moving everything to the right place **BUT, it's strongly advised to do a backup of your repositories and of the gogs directory before the update**. Your avatars and issue attachments files may be lost in the process.
+## Info on upgrading from the old package version (gogs <0.9.xx)
+Previous versions of this package used to build Gogs from sources instead of using the pre-compiled binary. It also left data in many places which was not good. The upgrade tries to take care of moving everything to the right place **BUT it's strongly advised to do a backup of your repositories and of the Gogs directory before the update**. Your avatars and issue attachments files may be lost in the process.
 
-Plus, in some cases, gogs will not restart properly during the update, if so, you can rerun the update safely or try to start gogs with `sudo systemctl restart gogs.service`.
+Also, in some cases, Gogs will not restart properly during the update. If so, you can rerun the update safely or try to start Gogs with `sudo systemctl restart gogs.service`.
 
 Sources and issues of the old package can be found [here](https://github.com/YunoHost-Apps/gogs_ynh_old/)
 
-## Infos
+## Info
 Gogs v0.9.71
 
 - [YunoHost forum thread](https://forum.yunohost.org/t/gogs-package-an-awesome-github-alternative/1127)
 
-Architecture: this package is compatible with amd64, i386 and arm, the package will try to detect it with the command uname -m and fail if it can't find it. If that happen please open an issue describing your hardware and the result of the command `uname -m`.
+Architecture: this package is compatible with amd64, i386 and arm. The package will try to detect it with the command uname -m and fail if it can't detect the architecture. If that happens please open an issue describing your hardware and the result of the command `uname -m`.
 
 ## License
-Gogs is published under MIT License
+Gogs is published under the MIT License:
 https://github.com/gogits/gogs/blob/master/LICENSE
 
-This package is published under MIT License
+This package is published under the MIT License.
 
 
-## Developper infos
-Please do your pull request to the dev branch.
+## Developper info
+Please do your pull requests to the `dev` branch.
 
 Test or upgrade to dev version:
 ```bash


### PR DESCRIPTION
- Fix english grammar & typos
- Consistently refer to Gogs as "Gogs" instead of "gogs"