### PR TITLE
[enh] linter fixes:

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
     "id": "gogs",
     "packaging_format": 1,
     "description": {
-        "en": "A self-hosted Git service written in Go",
-        "fr": "A self-hosted Git service written in Go"
+        "en": "Lightweight git forge",
+        "fr": "Forge git légère"
     },
     "url": "http://gogs.io",
     "license": "MIT",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -17,9 +17,8 @@ elif [ -n "$(uname -m | grep 86)" ]; then
 elif [ -n "$(uname -m | grep arm)" ]; then
 	ARCHITECTURE="raspi2_armv6"
 else
-	echo 'Unable to detect your achitecture, please open a bug describing \
-        your hardware and the result of the command "uname -m".'
-	exit 1
+	ynh_die "Unable to detect your achitecture, please open a bug describing \
+        your hardware and the result of the command \"uname -m\"." 1
 fi
 
 # Remote URL to fetch Gogs tarball

--- a/scripts/install
+++ b/scripts/install
@@ -3,10 +3,10 @@
 set -euo pipefail
 
 # Retrieve arguments
-domain=$1
-path=$2
-admin=$3
-is_public=$4
+domain=$YNH_APP_ARG_DOMAIN
+path=$YNH_APP_ARG_PATH
+admin=$YNH_APP_ARG_ADMIN
+is_public=$YNH_APP_ARG_PUBLIC_SITE
 
 # Load common variables
 source ./_common.sh

--- a/scripts/remove
+++ b/scripts/remove
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit and treat unset variables as an error
+set -u
+
 # Load common variables and helpers
 source ./_common.sh
 


### PR DESCRIPTION
- remove: add 'set -u'.
- install: retrieve arguments from env var.
- manifest: update descriptions.
- _common.sh: use 'ynh_die' helper.


Install, remove and upgrade works fine on ynh-dev.