### PR TITLE
[fix] create uploads folder and permissions

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -110,7 +110,7 @@ sudo cp ../conf/nginx.conf /etc/nginx/conf.d/$domain.d/"$app".conf
 
 # Create uploads folder and permissions
 sudo mkdir /opt/gogs/data
-sudo chown -R /opt/gogs/data
+sudo chown -R gogs /opt/gogs/data
 
 # Unprotect root from SSO if public
 if [ "$is_public" = "Yes" ]

--- a/scripts/install
+++ b/scripts/install
@@ -108,6 +108,10 @@ else
 fi
 sudo cp ../conf/nginx.conf /etc/nginx/conf.d/$domain.d/"$app".conf
 
+# Create uploads folder and permissions
+sudo mkdir /opt/gogs/data
+sudo chown -R /opt/gogs/data
+
 # Unprotect root from SSO if public
 if [ "$is_public" = "Yes" ]
 then


### PR DESCRIPTION
- Fix #26.
When uploading a file to a repository from web interface, a temporary folder is used on `/opt/gogs/data` wich needs `gogs` permissions.