### PR TITLE
Update Gogs version to 0.11.19.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Also, in some cases, Gogs will not restart properly during the update. If so, yo
 Sources and issues of the old package can be found [here](https://github.com/YunoHost-Apps/gogs_ynh_old/)
 
 ## Info
-Gogs v0.11
+Gogs v0.11.19
 
 - [YunoHost forum thread](https://forum.yunohost.org/t/gogs-package-an-awesome-github-alternative/1127)
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     },
     "url": "http://gogs.io",
     "license": "MIT",
-    "version": "0.11",
+    "version": "0.11.19",
     "maintainer": {
         "name": "tostaki",
         "email": "maxime@max.privy.place"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 APPNAME="gogs"
 
 # Gogs version
-VERSION="0.11"
+VERSION="0.11.19"
 
 # Detect the system architecture to download the right tarball
 # NOTE: `uname -m` is more accurate and universal than `arch`


### PR DESCRIPTION
### Upgrade from version ≤ 0.11.0 to v0.11.19

After upgrading, I [encountered this bug](https://github.com/gogits/gogs/issues/4618) which do not let gogs running.

The working solution I found is on [documentation](https://gogs.io/docs/upgrade/upgrade_from_binary) which must be done before upgrading:

```bash
cd /opt
mv gogs gogs_old
cp -R gogs_old/{custom,data} gogs
```
~~yunohost app upgrade gogs -f gogs@v0.11.9 --verbose~~

What solution do we want to take?
Do we make a condition on the `upgrade` script for versions ≤ 0.11.0 to execute upper code?